### PR TITLE
Clean up triage agent prompt

### DIFF
--- a/app/api/webhook/github/route.ts
+++ b/app/api/webhook/github/route.ts
@@ -252,7 +252,7 @@ export const POST = async (req: Request) => {
 	await incrementUsage(prisma, owner)
 
 	const {issue, pull_request: pr} = payload
-	const {pull_request: prComment} = issue
+	const prComment = issue?.pull_request
 
 	/**
 	 * Repo commands

--- a/app/api/webhook/github/route.ts
+++ b/app/api/webhook/github/route.ts
@@ -253,13 +253,7 @@ export const POST = async (req: Request) => {
 	await incrementUsage(prisma, owner)
 
 	const {
-		issue: {
-			node_id: issueId,
-			title,
-			number: issueNumber,
-			body,
-			labels: existingLabels
-		}
+		issue: {title, number: issueNumber, body, labels: existingLabels}
 	} = payload
 
 	const existingLabelNames = existingLabels?.map((l: Label) => l.name)
@@ -301,7 +295,7 @@ Your instructions: ${instructions}.
 			customerId,
 			repoFullName: `${owner}/${name}`,
 			issueNumber,
-			issueId,
+			issueId: issue?.node_id || null,
 			pullUrl: issue?.pull_request?.url || payload?.pull_request?.url || null,
 			allLabels
 		})

--- a/lib/agents/maige.ts
+++ b/lib/agents/maige.ts
@@ -38,7 +38,7 @@ export async function maige({
 	allLabels: any[]
 }) {
 	const tools = [
-		labelTool({octokit, allLabels}),
+		labelTool({octokit, allLabels, issueId}),
 		updateInstructionsTool({octokit, prisma, customerId, repoFullName}),
 		githubTool({octokit}),
 		codebaseSearch({customerId, repoFullName}),
@@ -50,8 +50,10 @@ export async function maige({
 	]
 
 	const prefix = `
-You are a project manager that is tagged when new issues come into GitHub.
-You are responsible for labelling the issues using the GitHub API.
+You are a project manager that is tagged when new issues and PRs come into GitHub.
+${
+	pullUrl ? '' : 'You are responsible for labelling issues using the GitHub API.'
+}
 You also maintain a set of user instructions that can customize your behaviour; you can write to these instructions at the request of a user.
 Repo full name: ${repoFullName}.
 `

--- a/lib/agents/maige.ts
+++ b/lib/agents/maige.ts
@@ -55,7 +55,12 @@ ${
 	pullUrl ? '' : 'You are responsible for labelling issues using the GitHub API.'
 }
 You also maintain a set of user instructions that can customize your behaviour; you can write to these instructions at the request of a user.
-Repo full name: ${repoFullName}.
+All repo labels: ${allLabels
+		.map(
+			({name, description}) =>
+				`${name}${description ? `: ${description.replaceAll(';', ',')}` : ''}`
+		)
+		.join('; ')}.
 `
 		.replaceAll('\n', ' ')
 		.replaceAll('\t', ' ')

--- a/lib/agents/maige.ts
+++ b/lib/agents/maige.ts
@@ -23,6 +23,7 @@ export async function maige({
 	customerId,
 	repoFullName,
 	issueNumber,
+	issueId,
 	pullUrl,
 	allLabels
 }: {
@@ -32,6 +33,7 @@ export async function maige({
 	customerId: string
 	repoFullName: string
 	issueNumber?: number
+	issueId?: string
 	pullUrl?: string
 	allLabels: any[]
 }) {
@@ -41,16 +43,17 @@ export async function maige({
 		githubTool({octokit}),
 		codebaseSearch({customerId, repoFullName}),
 		dispatchEngineer({issueNumber, repoFullName, customerId}),
-		...(issueNumber && [commentTool({octokit})]),
-		...(pullUrl && [
-			dispatchReviewer({octokit, pullUrl, repoFullName, customerId})
-		])
+		...(issueId ? [commentTool({octokit, issueId})] : []),
+		...(pullUrl
+			? [dispatchReviewer({octokit, pullUrl, repoFullName, customerId})]
+			: [])
 	]
 
 	const prefix = `
 You are a project manager that is tagged when new issues come into GitHub.
 You are responsible for labelling the issues using the GitHub API.
 You also maintain a set of user instructions that can customize your behaviour; you can write to these instructions at the request of a user.
+Repo full name: ${repoFullName}.
 `
 		.replaceAll('\n', ' ')
 		.replaceAll('\t', ' ')

--- a/lib/tools/comment.ts
+++ b/lib/tools/comment.ts
@@ -1,26 +1,31 @@
 import {DynamicStructuredTool} from 'langchain/tools'
 import {z} from 'zod'
+import {COPY} from '~/constants'
 import {addComment} from '~/utils/github'
 
 /**
  * Comment on an issue
  */
-export default function comment({octokit}: {octokit: any}) {
+export default function comment({
+	octokit,
+	issueId
+}: {
+	octokit: any
+	issueId: string
+}) {
 	return new DynamicStructuredTool({
 		description: 'Adds a comment to an issue',
-		func: async ({issueId, comment}) => {
-			const footer = `By [Maige](https://maige.app). How's my driving?`
+		func: async ({comment}) => {
 			const res = await addComment({
 				octokit,
 				issueId,
-				comment: `${comment}\n\n${footer}`
+				comment: `${comment}\n\n${COPY.FOOTER}`
 			})
 
 			return JSON.stringify(res)
 		},
 		name: 'addComment',
 		schema: z.object({
-			issueId: z.string().describe('The ID of the issue'),
 			comment: z.string().describe('The comment to add')
 		})
 	})

--- a/lib/tools/label.ts
+++ b/lib/tools/label.ts
@@ -8,19 +8,20 @@ import {labelIssue} from '~/utils/github'
  */
 export function labelTool({
 	octokit,
-	allLabels
+	allLabels,
+	issueId
 }: {
 	octokit: any
 	allLabels: Label[]
+	issueId: string
 }) {
 	return new DynamicStructuredTool({
 		description: 'Adds a label to an issue',
 		name: 'labelIssue',
 		schema: z.object({
-			issueId: z.string().describe('The ID of the issue'),
 			labelNames: z.array(z.string()).describe('The names of labels to apply')
 		}),
-		func: async ({issueId, labelNames}) => {
+		func: async ({labelNames}) => {
 			const res = await labelIssue({octokit, labelNames, allLabels, issueId})
 
 			return JSON.stringify(res)


### PR DESCRIPTION
- Move label + repo metadata fetch to helper function
- Remove issue ID from prompt to avoid common confusion. Anecdotally improves `githubTool` usage.