### PR TITLE
typesafe auth refactor

### DIFF
--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -26,6 +26,7 @@ export const authOptions: AuthOptions = {
 			profile(profile: GithubProfile): Profile {
 				// Add user profile information
 				return {
+					id: profile.id.toString(),
 					githubUserId: profile.id.toString(),
 					name: profile.name,
 					email: profile.email,

--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -39,6 +39,7 @@ export const authOptions: AuthOptions = {
 		session: async ({session, user}) => {
 			session.user.id = user.id
 			session.user.userName = user.userName
+			session.user.usage = user.usage
 			return session
 		}
 	}

--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -1,7 +1,6 @@
 import {PrismaAdapter} from '@auth/prisma-adapter'
-import type {Profile} from 'next-auth'
-import {AuthOptions} from 'next-auth'
-import GithubProvider, {type GithubProfile} from 'next-auth/providers/github'
+import {AuthOptions, Profile} from 'next-auth'
+import GithubProvider from 'next-auth/providers/github'
 import prisma from '~/prisma'
 import env from './env.mjs'
 
@@ -24,7 +23,7 @@ export const authOptions: AuthOptions = {
 		GithubProvider({
 			clientId: env.GITHUB_CLIENT_ID as string,
 			clientSecret: env.GITHUB_CLIENT_SECRET as string,
-			profile(profile: GithubProfile): Profile {
+			profile(profile): Profile {
 				// Add user profile information
 				return {
 					id: profile.id.toString(),

--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -1,13 +1,13 @@
 import {PrismaAdapter} from '@auth/prisma-adapter'
+import type {Profile} from 'next-auth'
 import {AuthOptions} from 'next-auth'
-import {AdapterUser} from 'next-auth/adapters'
 import GithubProvider, {type GithubProfile} from 'next-auth/providers/github'
 import prisma from '~/prisma'
 import env from './env.mjs'
 
 const prismaAdapter = PrismaAdapter(prisma)
 
-prismaAdapter.createUser = (data: AdapterUser & {userName: string}) => {
+prismaAdapter.createUser = data => {
 	return prisma.user.upsert({
 		// migration flow
 		where: {userName: data.userName},
@@ -24,7 +24,7 @@ export const authOptions: AuthOptions = {
 		GithubProvider({
 			clientId: env.GITHUB_CLIENT_ID as string,
 			clientSecret: env.GITHUB_CLIENT_SECRET as string,
-			profile(profile: GithubProfile) {
+			profile(profile: GithubProfile): Profile {
 				// Add user profile information
 				return {
 					id: profile.id.toString(),
@@ -39,7 +39,7 @@ export const authOptions: AuthOptions = {
 	callbacks: {
 		session: async ({session, user}) => {
 			session.user.id = user.id
-			session.user.userName = (user as AdapterUser & {userName: string}).userName
+			session.user.userName = user.userName
 			return session
 		}
 	}

--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -26,7 +26,7 @@ export const authOptions: AuthOptions = {
 			profile(profile: GithubProfile): Profile {
 				// Add user profile information
 				return {
-					id: profile.id.toString(),
+					githubUserId: profile.id.toString(),
 					name: profile.name,
 					email: profile.email,
 					image: profile.avatar_url,

--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -1,6 +1,6 @@
 import {PrismaAdapter} from '@auth/prisma-adapter'
 import {AuthOptions, Profile} from 'next-auth'
-import GithubProvider from 'next-auth/providers/github'
+import GithubProvider, {GithubProfile} from 'next-auth/providers/github'
 import prisma from '~/prisma'
 import env from './env.mjs'
 
@@ -23,7 +23,7 @@ export const authOptions: AuthOptions = {
 		GithubProvider({
 			clientId: env.GITHUB_CLIENT_ID as string,
 			clientSecret: env.GITHUB_CLIENT_SECRET as string,
-			profile(profile): Profile {
+			profile(profile: GithubProfile): Profile {
 				// Add user profile information
 				return {
 					id: profile.id.toString(),

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -9,14 +9,16 @@ import type {AdapterUser as DefaultAdapterUser} from 'next-auth/adapters'
 
 /* ************ EDIT ************ */
 
-interface ExtendedUser extends Pick<User, 'userName' | 'githubUserId'> {}
+interface ExtendedUser
+	extends DefaultUser,
+		Pick<User, 'userName' | 'githubUserId'> {}
 
 interface ExtendedSessionUser extends DefaultUser, Pick<User, 'userName'> {}
 
 /* ********* DON'T EDIT ********* */
 
 declare module 'next-auth' {
-	interface Profile extends DefaultProfile, ExtendedUser {}
+	interface Profile extends DefaultProfile, Omit<ExtendedUser, 'id'> {}
 
 	interface User extends ExtendedUser {
 		id?: User['id']

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,22 +1,27 @@
 import 'next-auth'
-import {DefaultSession} from 'next-auth'
+import type {Profile as DefaultProfile} from 'next-auth'
+import {DefaultSession, DefaultUser} from 'next-auth'
+import type {AdapterUser as DefaultAdapterUser} from 'next-auth/adapters'
+
+// Make changes to the ExtendedUser interface to see them in session, profile, DB
+interface ExtendedUser extends DefaultUser {
+	userName: string
+}
 
 declare module 'next-auth' {
 	/**
 	 * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
 	 */
-	interface Session {
-		user: {
-			id: string
-			userName: string
-		} & DefaultSession['user']
+
+	interface User extends ExtendedUser {}
+
+	interface Session extends DefaultSession {
+		user: User
 	}
 
-	interface Profile {
-		id: string
-		name: string
-		email: string
-		image: string
-		userName: string
-	}
+	interface Profile extends DefaultProfile, ExtendedUser {}
+}
+
+declare module '@auth/core/adapters' {
+	interface AdapterUser extends DefaultAdapterUser, ExtendedUser {}
 }

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -9,9 +9,7 @@ import type {AdapterUser as DefaultAdapterUser} from 'next-auth/adapters'
 
 /* ************ EDIT ************ */
 
-interface ExtendedUser
-	extends Omit<ExtendedUser, 'id'>,
-		Pick<User, 'userName' | 'githubUserId'> {}
+interface ExtendedUser extends Pick<User, 'userName' | 'githubUserId'> {}
 
 interface ExtendedSessionUser extends DefaultUser, Pick<User, 'userName'> {}
 
@@ -21,7 +19,7 @@ declare module 'next-auth' {
 	interface Profile extends DefaultProfile, ExtendedUser {}
 
 	interface User extends ExtendedUser {
-		id?: string
+		id?: User['id']
 	}
 
 	interface Session extends DefaultSession {

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -5,13 +5,13 @@ import {DefaultSession, DefaultUser} from 'next-auth'
 import type {AdapterUser as DefaultAdapterUser} from 'next-auth/adapters'
 
 // Make changes to the ExtendedUser and ExtendedSessionUser interfaces
-// Pick these from DB schema ex. 'username' | 'usage' | ...
+// Pick these from DB schema ex. Pick<User, 'usage' | 'email' | ...
 
 /* ************ EDIT ************ */
 
 interface ExtendedUser extends DefaultUser, Pick<User, 'userName'> {}
 
-interface ExtendedSessionUser extends ExtendedUser, Pick<User, 'usage'> {}
+interface ExtendedSessionUser extends ExtendedUser, Pick<User> {}
 
 /* ********* DON'T EDIT ********* */
 

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,27 +1,34 @@
+import {User} from '@prisma/client'
 import 'next-auth'
 import type {Profile as DefaultProfile} from 'next-auth'
 import {DefaultSession, DefaultUser} from 'next-auth'
 import type {AdapterUser as DefaultAdapterUser} from 'next-auth/adapters'
 
-// Make changes to the ExtendedUser interface to see them in session, profile, DB
-interface ExtendedUser extends DefaultUser {
-	userName: string
-}
+// Make changes to the ExtendedUser and ExtendedSessionUser interfaces
+// Pick these from DB schema ex. 'username' | 'usage' | ...
+
+/* ************ EDIT ************ */
+
+interface ExtendedUser extends DefaultUser, Pick<User, 'userName'> {}
+
+interface ExtendedSessionUser extends ExtendedUser, Pick<User, 'usage'> {}
+
+/* ********* DON'T EDIT ********* */
 
 declare module 'next-auth' {
-	/**
-	 * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
-	 */
+	interface Profile extends DefaultProfile, ExtendedUser {}
 
 	interface User extends ExtendedUser {}
 
 	interface Session extends DefaultSession {
-		user: User
+		user: ExtendedSessionUser
 	}
-
-	interface Profile extends DefaultProfile, ExtendedUser {}
 }
 
 declare module '@auth/core/adapters' {
 	interface AdapterUser extends DefaultAdapterUser, ExtendedUser {}
+}
+
+declare module 'next-auth/adapters' {
+	interface AdapterUser extends DefaultAdapterUser, ExtendedSessionUser {}
 }

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -9,16 +9,20 @@ import type {AdapterUser as DefaultAdapterUser} from 'next-auth/adapters'
 
 /* ************ EDIT ************ */
 
-interface ExtendedUser extends DefaultUser, Pick<User, 'userName'> {}
+interface ExtendedUser
+	extends Omit<ExtendedUser, 'id'>,
+		Pick<User, 'userName' | 'githubUserId'> {}
 
-interface ExtendedSessionUser extends ExtendedUser, Pick<User> {}
+interface ExtendedSessionUser extends DefaultUser, Pick<User, 'userName'> {}
 
 /* ********* DON'T EDIT ********* */
 
 declare module 'next-auth' {
 	interface Profile extends DefaultProfile, ExtendedUser {}
 
-	interface User extends ExtendedUser {}
+	interface User extends ExtendedUser {
+		id?: string
+	}
 
 	interface Session extends DefaultSession {
 		user: ExtendedSessionUser

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -13,7 +13,9 @@ interface ExtendedUser
 	extends DefaultUser,
 		Pick<User, 'userName' | 'githubUserId'> {}
 
-interface ExtendedSessionUser extends DefaultUser, Pick<User, 'userName'> {}
+interface ExtendedSessionUser
+	extends DefaultUser,
+		Pick<User, 'userName' | 'usage'> {}
 
 /* ********* DON'T EDIT ********* */
 

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -5,7 +5,7 @@ import {DefaultSession, DefaultUser} from 'next-auth'
 import type {AdapterUser as DefaultAdapterUser} from 'next-auth/adapters'
 
 // Make changes to the ExtendedUser and ExtendedSessionUser interfaces
-// Pick these from DB schema ex. Pick<User, 'usage' | 'email' | ...
+// Pick these from DB schema ex. Pick<User, 'userName' | 'usage' | ...
 
 /* ************ EDIT ************ */
 
@@ -20,11 +20,9 @@ interface ExtendedSessionUser
 /* ********* DON'T EDIT ********* */
 
 declare module 'next-auth' {
-	interface Profile extends DefaultProfile, Omit<ExtendedUser, 'id'> {}
+	interface Profile extends DefaultProfile, ExtendedUser {}
 
-	interface User extends ExtendedUser {
-		id?: User['id']
-	}
+	interface User extends ExtendedUser {}
 
 	interface Session extends DefaultSession {
 		user: ExtendedSessionUser


### PR DESCRIPTION
[Loom](https://www.loom.com/share/553396e7ee4a4d2a85b2878a90224127?sid=4d253d14-4266-4371-867f-d7dd051bee45)

This PR implements extensions on the next-auth types.
In theory, this is a really clean way to extend the user type and see it reflected across auth from DB to session, etc.