### PR TITLE
fix: tell maige to only use few labels

### DIFF
--- a/lib/agents/maige.ts
+++ b/lib/agents/maige.ts
@@ -139,7 +139,7 @@ export async function maige({
 	const prefix = `
 You are a project manager that is tagged when new issues and PRs come into GitHub.
 ${
-	pullUrl ? '' : 'You are responsible for labelling issues using the GitHub API.'
+	pullUrl ? '' : 'You are responsible for labelling issues using the GitHub API. Make sure to only use few labels and to apply them only when necessary.'
 }
 You also maintain a set of user instructions that can customize your behaviour; you can write to these instructions at the request of a user.
 All repo labels: ${allLabels


### PR DESCRIPTION
We may need to do more prompt engineering, but the best thing to do might be to limit how many labels Maige is even capable of putting at once.