### PR TITLE
Fix: add Dialog Title to CreateInstructions

### DIFF
--- a/lib/components/dashboard/Instructions/CreateInstruction.tsx
+++ b/lib/components/dashboard/Instructions/CreateInstruction.tsx
@@ -2,7 +2,7 @@
 
 import { PlusIcon } from 'lucide-react'
 import { useState } from 'react'
-import { Dialog, DialogContent, DialogTrigger } from '~/components/ui/dialog'
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '~/components/ui/dialog'
 import CreateInstructionForm from './CreateInstructionForm'
 
 type Props = {
@@ -19,6 +19,7 @@ export default function CreateInstruction({ projectId }: Props) {
 				Add instruction
 			</DialogTrigger>
 			<DialogContent>
+				<DialogTitle className="sr-only">Create New Instruction</DialogTitle>
 				<CreateInstructionForm projectId={projectId} setDialogOpen={setOpen} />
 			</DialogContent>
 		</Dialog>


### PR DESCRIPTION
Added a screen reader-only DialogTitle to the CreateInstruction component to resolve accessibility warnings. This fix ensures our dialogs are properly labeled for users with screen readers while maintaining the current visual design. The change addresses the console warnings related to missing DialogTitle requirements from Radix UI.